### PR TITLE
feat: add customizable diagnostic types

### DIFF
--- a/flymake-jsts-biome.el
+++ b/flymake-jsts-biome.el
@@ -95,8 +95,8 @@ the buffer containing biome's own output."
 													 (severity (if (string= (gethash "severity"
 																													 el-d)
 																									"error")
-																				 :error
-																			 :warning))
+																				 flymake-jsts-error-type
+																			 flymake-jsts-warning-type))
 													 (start-pos (elt (gethash "span"
 																										(gethash "location"
 																														 el-d))

--- a/flymake-jsts-eslint.el
+++ b/flymake-jsts-eslint.el
@@ -77,8 +77,8 @@ the buffer containing eslint's own output."
 										(severity (if (equal (gethash "severity"
 																									el)
 																				 1)
-																	:warning
-																:error))
+																	flymake-jsts-warning-type
+																flymake-jsts-error-type))
 										(start-pos (flymake-jsts/get-pos-from-line-and-column start-line
 																																					start-column
 																																					source-buffer))

--- a/flymake-jsts-oxlint.el
+++ b/flymake-jsts-oxlint.el
@@ -69,8 +69,8 @@ the buffer containing oxlint's own output."
 													 (severity (if (string= (gethash "severity"
 																													 el-d)
 																									"warning")
-																				 :warning
-																			 :error))
+																				 flymake-jsts-warning-type
+																			 flymake-jsts-error-type))
 													 (labels (gethash "labels"
 																						el-d)))
 											(append acc

--- a/flymake-jsts-utils.el
+++ b/flymake-jsts-utils.el
@@ -31,7 +31,7 @@ case of linter crash or malfunction."
 	(flymake-make-diagnostic source-buffer
 													 0
 													 1
-													 :error
+													 flymake-jsts-error-type
 													 (with-current-buffer source-buffer
 														 (buffer-substring-no-properties (point-min) (point-max)))))
 

--- a/flymake-jsts.el
+++ b/flymake-jsts.el
@@ -64,6 +64,17 @@ by your linter), or nil to supporess."
 	:type 'boolean
 	:group 'flymake-jsts)
 
+(defcustom flymake-jsts-error-type :error
+	"Diagnostic type symbol to use when reporting errors.
+(see `(flymake) Flymake error types')"
+	:type 'symbol
+	:group 'flymake-jsts)
+
+(defcustom flymake-jsts-error-warning :warning
+	"Diagnostic type symbol to use when reporting warnings.
+(see `(flymake) Flymake error types')"
+	:type 'symbol
+	:group 'flymake-jsts)
 
 (defvar flymake-jsts/debug nil
 	"Internal variable.  Set to non-nil to enable debug logging.")


### PR DESCRIPTION
Flymake comes with three preconfigured diagnostic types, represented by symbols: `:error`, `:warning`, and `:note`. These symbols are arbitrary, and a flymake backend can create diagnostics using whichever symbols it wants.

Giving the user an easy way to set their own diagnostic types makes it possible to specifically customize the diagnostics reported by flymake-jsts. (see `(flymake) Flymake error types')

In my case, this is useful for visually distinguishing lint errors from LSP errors.