### PR TITLE
fix: correctly handle errors due to eslint not working correctly

### DIFF
--- a/flymake-jsts.el
+++ b/flymake-jsts.el
@@ -1,6 +1,6 @@
 ;;; flymake-jsts.el --- A Flymake backend for Javascript and Typescript  -*- lexical-binding: t; -*-
 
-;; Version: 1.2.1
+;; Version: 1.2.2
 ;; Author: Dan Orzechowski
 ;; URL: https://github.com/orzechowskid/flymake-jsts
 ;; Package-Requires: ((emacs "29") (pfuture "1.10.3"))


### PR DESCRIPTION
errors preventing eslint from working (like malformed config files, errors with individual plugins, etc) were not being correctly reported